### PR TITLE
Filter by day backend

### DIFF
--- a/activities/tests/shortcuts.py
+++ b/activities/tests/shortcuts.py
@@ -93,3 +93,15 @@ def client_join_activity(client: django.test.Client, user: User, activity: model
     client.force_login(user)
     client.post(urls.reverse("activities:join", args=[activity.id]))
     activity.refresh_from_db()
+
+
+def convert_day_num(day_num: int) -> int:
+    """Convert day num from python format (0 = Monday. 6 = Sunday) to MySQL format (1 = Sunday, 7 = Saturday).
+
+    :param day_num: Day num in Python format
+    :return: Day num in MySQL format
+    """
+    if day_num == 6:
+        return 1
+
+    return day_num + 2

--- a/activities/tests/test_detail.py
+++ b/activities/tests/test_detail.py
@@ -13,7 +13,8 @@ class DetailTest(django.test.TestCase):
         """Past activities should not be accessible."""
         _, activity = create_activity(days_delta=-1)
         response = self.client.get(urls.reverse("activities:detail", args=[activity.id]))
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(response.content, activity_to_json(activity))
 
     def test_future_activity(self):
         """Future/Upcoming activity should be accessible."""

--- a/activities/views/activity_detail.py
+++ b/activities/views/activity_detail.py
@@ -14,7 +14,7 @@ class ActivityDetail(mixins.RetrieveModelMixin,
                      generics.GenericAPIView):
     """Return detail of an activity when GET request, and edit the activity when PUT request."""
 
-    queryset = models.Activity.objects.filter(date__gte=timezone.now())
+    queryset = models.Activity.objects.all()
     serializer_class = model_serializers.ActivitiesSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly, OnlyHostCanEdit]
 

--- a/activities/views/activity_list.py
+++ b/activities/views/activity_list.py
@@ -32,7 +32,6 @@ class ActivityList(
             queryset = queryset.filter(Q(name__iregex=rf'{keyword}') | Q(detail__iregex=rf'{keyword}'))
 
         day = self.__parse_date(self.request.GET.get("day"))
-        print(day)
         if day:
             queryset = queryset.filter(date__week_day__in=day)
 
@@ -77,17 +76,15 @@ class ActivityList(
         )
 
     def __parse_date(self, date_param: str) -> list[int] | None:
-        
+
         day_list_format = r'^(?:[1-7](?:,[1-7])*)?$'
-        
+
         if (not date_param) or (not re.fullmatch(day_list_format, date_param)):
             return None
-        
+
         split_day = date_param.split(',')
-        
+
         if len(split_day) > 7:
             return None
-        
-        print(split_day)
-        
+
         return [int(s.strip()) for s in split_day]


### PR DESCRIPTION
### Description
- Implement filter by day of week backend #154 
- DetailView able to return expired activity #155 
- 
### Functional Acceptance Criteria (Not required for Documentation update)
- `GET activities/?day=<day of week num seperated by comma>` Return list of activity that take time on day that in day of week list. More detail about day num format in additional information.
- `GET activities/<activity_id>/` are now able to return activity that has expired.
### Checklist (Not required for Documentation update)

- [x] I have performed a self-review of my code.
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation, if applicable.
- [x] My code follows the Coding Guidelines.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please specify)

### Additional Information
day format
1 = Sunday
2 = Monday
3 = Tuesday
4 = Wednesday
5 = Thursday
6 = Friday
7 = Saturday 
Example: 
`GET activities/?day=1,2,3` Will return list of activities in Sunday, Monday, Tuesday
`GET activities/?day=7` Will return list of activities in Saturday

