### PR TITLE
Check join api

### DIFF
--- a/activities/tests/test_join.py
+++ b/activities/tests/test_join.py
@@ -231,3 +231,23 @@ class JoinTest(django.test.TestCase):
         self.assertJSONEqual(
             response.content, {'message': f'Your reputation score is too low to join {act_with_min_rep.name}'}
         )
+
+    def test_is_join_api(self):
+        """Is join API should correctly return user activity join status correctly."""
+        _, act = create_activity(host=self.host)
+
+        # Check unauthenticated user
+        self.client.logout()
+        res = self.client.get(f'/activities/{act.id}/is-joined/')
+        self.assertJSONEqual(res.content, {'is-joined': False})
+
+        # Check authenticated user that not join yet
+        attendee = create_test_user('join user')
+        self.client.force_login(attendee)
+        res = self.client.get(f'/activities/{act.id}/is-joined/')
+        self.assertJSONEqual(res.content, {'is-joined': False})
+
+        # Check user that already join
+        client_join_activity(client=self.client, user=attendee, activity=act)
+        res = self.client.get(f'/activities/{act.id}/is-joined/')
+        self.assertJSONEqual(res.content, {'is-joined': True})

--- a/activities/tests/test_join.py
+++ b/activities/tests/test_join.py
@@ -245,7 +245,7 @@ class JoinTest(django.test.TestCase):
         attendee = create_test_user('join user')
         self.client.force_login(attendee)
         res = self.client.get(f'/activities/{act.id}/is-joined/')
-        self.assertJSONEqual(res.content, {'is-joined': False})
+        self.assertJSONEqual(res.content, {'is_joined': False})
 
         # Check user that already join
         client_join_activity(client=self.client, user=attendee, activity=act)

--- a/activities/urls.py
+++ b/activities/urls.py
@@ -13,5 +13,6 @@ urlpatterns = [
 
     # Utilities.
     path('get-csrf-token/', views.util.csrf_token_view, name='get_csrf_token'),
-    path('get-recently/<int:id>/', views.util.get_recent_activity, name='get_recently')
+    path('get-recently/<int:id>/', views.util.get_recent_activity, name='get_recently'),
+    path("<int:id>/is-joined/", views.util.check_is_joined, name="is-joined"),
 ]

--- a/activities/views/util.py
+++ b/activities/views/util.py
@@ -19,6 +19,25 @@ CHECKIN_CODE_LEN = 6
 
 
 @decorators.api_view(['get'])
+def check_is_joined(request: HttpRequest, *args: Any, **kwargs: Any) -> response.Response:
+    """Check does current user are participating activity or not.
+
+    :param request: HttpRequest object.
+    :return: Json file with a key "is-joined" and boolean value which tell does user participant in activity or not
+    """
+    if not request.user.is_authenticated:
+        return response.Response(
+            {'is-joined': False}
+        )
+
+    activity = get_object_or_404(models.Activity, id=kwargs.get('id'))
+
+    return response.Response(
+        {'is-joined': activity.is_participated(request.user)}
+    )
+
+
+@decorators.api_view(['get'])
 def csrf_token_view(request: HttpRequest) -> response.Response:  # pragma: no cover
     """Return csrf token."""
     csrf_token = get_token(request)

--- a/activities/views/util.py
+++ b/activities/views/util.py
@@ -33,7 +33,7 @@ def check_is_joined(request: HttpRequest, *args: Any, **kwargs: Any) -> response
     activity = get_object_or_404(models.Activity, id=kwargs.get('id'))
 
     return response.Response(
-        {'is-joined': activity.is_participated(request.user)}
+        {'is_joined': activity.is_participated(request.user)}
     )
 
 

--- a/frontend/src/views/ActivityChat.vue
+++ b/frontend/src/views/ActivityChat.vue
@@ -449,9 +449,8 @@ const checkJoined = () => {
      * Check if current user joined the activity
      * return boolean whether or not user is joined
      */
-    isJoined.value = people.value.some(
-        (element) => element['user']['id'] == authUserId.value
-    );
+    const response = apiClient.get(`/activities/${activityId.value}/is-joined/`)
+    isJoined.value = response.data.is_joined
 };
 
 /**

--- a/frontend/src/views/ActivityDetail.vue
+++ b/frontend/src/views/ActivityDetail.vue
@@ -504,10 +504,8 @@ const isOwner = computed(() => {
 });
 
 const isJoined = computed(() => {
-    return (
-        isAuth &&
-        people.value.some((participant) => participant.user.id === userId.value)
-    );
+    const response = apiClient.get(`/activities/${activityId.value}/is-joined/`)
+    return response.data.is_joined
 });
 
 const imagesUrl = computed(() => {


### PR DESCRIPTION
### Description

- Add API endpoint to check whether user are join an activity or not. #225 

### Functional Acceptance Criteria 

- As unauthenticated user when `GET /activities/<activity_id>/is-joined/` should return value {Is-joined: false}
- As authenticated user that haven't join an activity yet when `GET /activities/<activity_id>/is-joined/` should return value {Is-joined: false}
- As authenticated user that have join an activity when `GET /activities/<activity_id>/is-joined/` should return value {Is-joined: true}


### Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation, if applicable.
- [x] My code follows the Coding Guidelines.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please specify)
