### PR TITLE
Add path to CA for an database connection option

### DIFF
--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -9,7 +9,7 @@ omit =
     manage.py ,    # Exclude manage.py (Django entry point)
     .github/*,    # Exclude github directory
     auth/*,
-    */settings.py/*
+    */settings.py
 
 [report]
 # Report additional information on missing lines

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -9,6 +9,7 @@ omit =
     manage.py ,    # Exclude manage.py (Django entry point)
     .github/*,    # Exclude github directory
     auth/*,
+    */settings.py/*
 
 [report]
 # Report additional information on missing lines

--- a/backend/mysite/settings.py
+++ b/backend/mysite/settings.py
@@ -107,14 +107,18 @@ DATABASES = {
         'PASSWORD': config('DATABASE_PASSWORD', default='password', cast=str),
         'HOST': config('DATABASE_HOST', default='localhost', cast=str),
         'PORT': config('DATABASE_PORT', default='3306', cast=str),
-        'OPTIONS': {
+        
+    }
+}
+
+REQUIRE_SSL = config('REQUIRE_SSL', default=False, cast=bool)
+
+if REQUIRE_SSL:
+    DATABASES['default']['OPTIONS'] = {
             'ssl': {
                 'ca': config('PATH_TO_CA', default="/etc/ssl/cert.pem", cast=str)
             },
         }
-    }
-}
-
 
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators

--- a/backend/mysite/settings.py
+++ b/backend/mysite/settings.py
@@ -107,6 +107,11 @@ DATABASES = {
         'PASSWORD': config('DATABASE_PASSWORD', default='password', cast=str),
         'HOST': config('DATABASE_HOST', default='localhost', cast=str),
         'PORT': config('DATABASE_PORT', default='3306', cast=str),
+        'OPTIONS': {
+            'ssl': {
+                'ca': config('PATH_TO_CA', default="/etc/ssl/cert.pem", cast=str)
+            },
+        }
     }
 }
 

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -11,7 +11,8 @@ DATABASE_USER=root
 DATABASE_PASSWORD=password
 DATABASE_HOST=localhost
 DATABASE_PORT=3306
-# For cloud database connecttion
+REQUIRE_SSL=False
+# For cloud database connection set REQUIRE_SSL to True
 PATH_TO_CA=/etc/ssl/cert.pem
 
 # CSRF configuration

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -11,6 +11,8 @@ DATABASE_USER=root
 DATABASE_PASSWORD=password
 DATABASE_HOST=localhost
 DATABASE_PORT=3306
+# For cloud database connecttion
+PATH_TO_CA=/etc/ssl/cert.pem
 
 # CSRF configuration
 ALLOWED_CSRF = http://localhost:8080, http://127.0.0.1:8080


### PR DESCRIPTION
### Description

- Add path to CA for an database connection option

### Functional Acceptance Criteria

- Able to connect to database inside google cloud run

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

### Additional Information 
- set `REQUIRE_SSL` to True when require ssl connection
- Need to add `PATH_TO_CA` variable In .env file If `REQUIRE_SSL` True